### PR TITLE
fix: url and cargo typo

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "faucuet-bot-testnet"
+name = "faucet-bot-testnet"
 version = "0.1.0"
 authors = ["Charalampos Mitrodimas <liompis@cherrylabs.org>"]
 edition = "2018"

--- a/src/commands/claim.rs
+++ b/src/commands/claim.rs
@@ -31,7 +31,7 @@ async fn claim(ctx: &Context, msg: &Message, args: Args) -> CommandResult {
     };
 
     let api =
-        OnlineClient::<PolkadotConfig>::from_url("wss://testnet-seeder.cherrynetwork.dev")
+        OnlineClient::<PolkadotConfig>::from_url("wss://testnet-seeder.cherrynetwork.dev:443")
             .await
             .unwrap();
 


### PR DESCRIPTION
Fix a type in the cargo.toml and added the port to the api url (I tried to run the BOT and it panicked without the port).